### PR TITLE
Bump the log level of CloudEvent

### DIFF
--- a/quarkus/src/main/java/com/redhat/openshift/knative/showcase/events/Rest.java
+++ b/quarkus/src/main/java/com/redhat/openshift/knative/showcase/events/Rest.java
@@ -31,7 +31,7 @@ class Rest implements Endpoint {
   @Override
   public void receive(CloudEvent event) {
     var he = presenter.asHumanReadable(event);
-    LOGGER.debug("Received event:\n{}", he);
+    LOGGER.info("Received event:\n{}", he);
     events.add(event);
   }
 


### PR DESCRIPTION
The Quarkus app doesn't print the event on the default log level. I missed that on #25.

Follow up to #25 