### PR TITLE
handle undefined datacontenttype both in cli and webconsole output

### DIFF
--- a/expressjs/src/routes/events/printer.js
+++ b/expressjs/src/routes/events/printer.js
@@ -116,7 +116,7 @@ function printData(ce) {
   let buf = ''
   if (ce.data) {
     buf += `Data,\n`
-    if (ce.datacontenttype === 'application/json') {
+    if (ce.datacontenttype === null || ce.datacontenttype === 'application/json') {
       const data = indent(JSON.stringify(ce.data, ' ', 2), 1, 2)
       buf += `${data}\n`
       return buf

--- a/frontend/src/components/left-column.tsx
+++ b/frontend/src/components/left-column.tsx
@@ -95,7 +95,7 @@ class LeftColumn extends React.Component<LeftColumnProps, LeftColumnState> {
   }
 
   private stringifyData(ce: CloudEvent): React.ReactNode {
-    if (ce.datacontenttype?.startsWith('application/json')) {
+    if (ce.datacontenttype?.startsWith('application/json') || ce.datacontenttype?.startsWith('undefined datacontenttype')) {
       return this.highlightCode(JSON.stringify(ce.data, null, 2), 'json')
     }
     return (

--- a/frontend/src/components/left-column.tsx
+++ b/frontend/src/components/left-column.tsx
@@ -72,7 +72,7 @@ class LeftColumn extends React.Component<LeftColumnProps, LeftColumnState> {
                   <div className="value">{ce.source}</div>
                 </td>
                 <th rowSpan={2}>
-                  <label>{ce.datacontenttype}</label>
+                  <label>{this.getDataContentType(ce)}</label>
                   <div className="value">{this.stringifyData(ce)}</div>
                 </th>
               </tr>
@@ -94,8 +94,16 @@ class LeftColumn extends React.Component<LeftColumnProps, LeftColumnState> {
     })
   }
 
+  private getDataContentType(ce: CloudEvent): string {
+    if (ce.datacontenttype == null) {
+      return "undefined datacontenttype"
+    } else {
+      return ce.datacontenttype
+    }
+  }
+
   private stringifyData(ce: CloudEvent): React.ReactNode {
-    if (ce.datacontenttype?.startsWith('application/json') || ce.datacontenttype?.startsWith('undefined datacontenttype')) {
+    if (ce.datacontenttype == null || ce.datacontenttype?.startsWith('application/json')) {
       return this.highlightCode(JSON.stringify(ce.data, null, 2), 'json')
     }
     return (

--- a/frontend/src/components/left-column.tsx
+++ b/frontend/src/components/left-column.tsx
@@ -96,7 +96,7 @@ class LeftColumn extends React.Component<LeftColumnProps, LeftColumnState> {
 
   private getDataContentType(ce: CloudEvent): string {
     if (ce.datacontenttype == null) {
-      return "undefined datacontenttype"
+      return "content type not specified"
     } else {
       return ce.datacontenttype
     }

--- a/frontend/src/events/u-cloudevents.ts
+++ b/frontend/src/events/u-cloudevents.ts
@@ -38,8 +38,6 @@ export class CloudEvent<T = any> implements CloudEventV1<T> {
 
     if (properties.datacontenttype) {
       this.datacontenttype = properties.datacontenttype
-    } else {
-      this.datacontenttype = "undefined datacontenttype"
     }
 
     delete properties.datacontenttype

--- a/frontend/src/events/u-cloudevents.ts
+++ b/frontend/src/events/u-cloudevents.ts
@@ -36,7 +36,12 @@ export class CloudEvent<T = any> implements CloudEventV1<T> {
     this.specversion = (properties.specversion as string) || '1.0'
     delete properties.specversion
 
-    this.datacontenttype = properties.datacontenttype
+    if (properties.datacontenttype) {
+      this.datacontenttype = properties.datacontenttype
+    } else {
+      this.datacontenttype = "undefined datacontenttype"
+    }
+
     delete properties.datacontenttype
 
     this.subject = properties.subject

--- a/quarkus/src/main/java/com/redhat/openshift/knative/showcase/events/Presenter.java
+++ b/quarkus/src/main/java/com/redhat/openshift/knative/showcase/events/Presenter.java
@@ -86,9 +86,6 @@ class Presenter {
     if (data != null) {
       buf.append("Data,\n");
       var contentType = ce.getDataContentType();
-      if (contentType == null) {
-        contentType = "undefined";
-      }
 
       if ("application/json".equals(contentType)) {
         var json = mapper.readValue(data.toBytes(), Object.class);
@@ -100,8 +97,8 @@ class Presenter {
         return buf;
       }
       var repr = data.toString();
-      var types = List.of("text", "xml", "html", "csv", "json", "yaml", "undefined");
-      if (types.stream().anyMatch(contentType::contains)) {
+      var types = List.of("text", "xml", "html", "csv", "json", "yaml");
+      if (contentType == null || types.stream().anyMatch(contentType::contains)) {
         repr = new String(data.toBytes(), StandardCharsets.UTF_8);
       }
       buf.append(repr.indent(INDENT_SIZE)).append("\n");

--- a/quarkus/src/main/java/com/redhat/openshift/knative/showcase/events/Presenter.java
+++ b/quarkus/src/main/java/com/redhat/openshift/knative/showcase/events/Presenter.java
@@ -86,7 +86,9 @@ class Presenter {
     if (data != null) {
       buf.append("Data,\n");
       var contentType = ce.getDataContentType();
-      assert contentType != null;
+      if (contentType == null) {
+        contentType = "undefined";
+      }
 
       if ("application/json".equals(contentType)) {
         var json = mapper.readValue(data.toBytes(), Object.class);
@@ -98,7 +100,7 @@ class Presenter {
         return buf;
       }
       var repr = data.toString();
-      var types = List.of("text", "xml", "html", "csv", "json", "yaml");
+      var types = List.of("text", "xml", "html", "csv", "json", "yaml", "undefined");
       if (types.stream().anyMatch(contentType::contains)) {
         repr = new String(data.toBytes(), StandardCharsets.UTF_8);
       }

--- a/quarkus/src/test/java/com/redhat/openshift/knative/showcase/events/PresenterTest.java
+++ b/quarkus/src/test/java/com/redhat/openshift/knative/showcase/events/PresenterTest.java
@@ -1,0 +1,69 @@
+package com.redhat.openshift.knative.showcase.events;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.cloudevents.core.builder.CloudEventBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import static org.junit.jupiter.api.Assertions.*;
+
+class PresenterTest {
+  private Presenter presenter;
+
+  @BeforeEach
+  void setup() {
+    presenter = new Presenter(new ObjectMapper());
+  }
+
+  @Test
+  void testAsHumanReadableWithNullTypeAndJson() {
+    // Arrange
+    String id = "123";
+    String type = null;
+    String data = "{\"msg\":\"Hello World!\"}";
+    var ce = CloudEventBuilder.v1()
+      .withId(id)
+      .withSource(URI.create("http://localhost"))
+      .withType("test")
+      .withData(type, data.getBytes(StandardCharsets.UTF_8))
+      .build();
+
+    String expected = """
+      ☁️  cloudevents.Event
+      Validation: valid
+      Context Attributes,
+        specversion: 1.0
+        id: 123
+        source: http://localhost
+        type: test
+      Data,
+        {"msg":"Hello World!"}
+        
+      """;
+    // Act
+    CharSequence actual = presenter.asHumanReadable(ce).toString();
+    // Assert
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  void testAsHumanReadableWithNullTypeAndBinary() {
+    // Arrange
+    String id = "123";
+    String type = null;
+    byte[] data={0xa, 0x2, (byte) 0xff};
+    var ce = CloudEventBuilder.v1()
+      .withId(id)
+      .withSource(URI.create("http://localhost"))
+      .withType("test")
+      .withData(type, data)
+      .build();
+
+    byte[] expected = new byte[] {-30, -104, -127, -17, -72, -113, 32, 32, 99, 108, 111, 117, 100, 101, 118, 101, 110, 116, 115, 46, 69, 118, 101, 110, 116, 10, 86, 97, 108, 105, 100, 97, 116, 105, 111, 110, 58, 32, 118, 97, 108, 105, 100, 10, 67, 111, 110, 116, 101, 120, 116, 32, 65, 116, 116, 114, 105, 98, 117, 116, 101, 115, 44, 10, 32, 32, 115, 112, 101, 99, 118, 101, 114, 115, 105, 111, 110, 58, 32, 49, 46, 48, 10, 32, 32, 105, 100, 58, 32, 49, 50, 51, 10, 32, 32, 115, 111, 117, 114, 99, 101, 58, 32, 104, 116, 116, 112, 58, 47, 47, 108, 111, 99, 97, 108, 104, 111, 115, 116, 10, 32, 32, 116, 121, 112, 101, 58, 32, 116, 101, 115, 116, 10, 68, 97, 116, 97, 44, 10, 32, 32, 10, 32, 32, 2, -17, -65, -67, 10, 10};
+    // Act
+    byte[] actual = presenter.asHumanReadable(ce).toString().getBytes();
+    // Assert
+    assertArrayEquals(expected, actual);
+  }
+}


### PR DESCRIPTION
Treat undefined datacontenttype as JSON (per specification: https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md?plain=1#L358)

When reproducing like this
```
kn service create event-consumer-web --image <path/to/my/fixed/image> --scale-min=1
kn source ping create ping-producer --data '{ "value": "Ping" }' --sink ksvc:event-consumer-web
```
The result is the following:

user-container output:
```
Received event:
showcase-00015-deployment-7dcc86b569-2j4vl user-container ☁  cloudevents.Event
showcase-00015-deployment-7dcc86b569-2j4vl user-container Validation: valid
showcase-00015-deployment-7dcc86b569-2j4vl user-container Context Attributes,
showcase-00015-deployment-7dcc86b569-2j4vl user-container   specversion: 1.0
showcase-00015-deployment-7dcc86b569-2j4vl user-container   id: 6dcfcf5e-1f67-4763-a38e-2599297d8cba
showcase-00015-deployment-7dcc86b569-2j4vl user-container   source: /apis/v1/namespaces/default/pingsources/ping-producer
showcase-00015-deployment-7dcc86b569-2j4vl user-container   time: 2023-07-02T11:47:00.473882901Z
showcase-00015-deployment-7dcc86b569-2j4vl user-container   type: dev.knative.sources.ping
showcase-00015-deployment-7dcc86b569-2j4vl user-container Data,
showcase-00015-deployment-7dcc86b569-2j4vl user-container   {"value": "Ping" }
showcase-00015-deployment-7dcc86b569-2j4vl user-container
showcase-00015-deployment-7dcc86b569-2j4vl user-container
```

Web console:
![image](https://github.com/openshift-knative/showcase/assets/5647515/f370995d-5bc4-4973-8394-5bcfbbaefe73)
